### PR TITLE
Add api client module

### DIFF
--- a/src/qgis_oacs/gui/data_source_widget.py
+++ b/src/qgis_oacs/gui/data_source_widget.py
@@ -11,7 +11,7 @@ from qgis.PyQt import (
 from qgis.PyQt.uic import loadUiType
 
 from .. import utils
-from ..client import OacsClient
+from ..client import oacs_client
 from ..settings import settings_manager
 from .search_datastream_items_widget import SearchDataStreamItemsWidget
 from .search_sampling_feature_items_widget import SearchSamplingFeatureItemsWidget
@@ -28,16 +28,11 @@ class OacsDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, DataSourceWidge
     connection_remove_btn: QtWidgets.QPushButton
     resource_types_tw: QtWidgets.QTabWidget
     resource_type_pages: dict[str, QtWidgets.QWidget]
-    resource_type_datastream_page: SearchDataStreamItemsWidget
-    resource_type_system_page: SearchSystemItemsWidget
-    resource_type_sampling_feature_page: SearchSamplingFeatureItemsWidget
     button_box: QtWidgets.QDialogButtonBox
     message_bar: qgis.gui.QgsMessageBar
 
     _connection_controls: tuple[QtWidgets.QWidget, ...]
     _interactive_widgets: tuple[QtWidgets.QWidget, ...]
-
-    oacs_client: OacsClient
 
     def __init__(
             self,
@@ -47,7 +42,6 @@ class OacsDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, DataSourceWidge
     ):
         super().__init__(parent, fl, widget_mode)
         self.setupUi(self)
-        self.oacs_client = OacsClient()
 
         self.grid_layout = QtWidgets.QGridLayout()
         self.message_bar = qgis.gui.QgsMessageBar()
@@ -60,16 +54,16 @@ class OacsDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, DataSourceWidge
         self.layout().insertLayout(4, self.grid_layout)
 
         self.resource_type_pages = {
-            "systems": SearchSystemItemsWidget(self.oacs_client),
-            "sampling features": SearchSamplingFeatureItemsWidget(self.oacs_client),
-            "datastreams": SearchDataStreamItemsWidget(self.oacs_client),
+            "systems": SearchSystemItemsWidget(),
+            "sampling features": SearchSamplingFeatureItemsWidget(),
+            "datastreams": SearchDataStreamItemsWidget(),
         }
         self.resource_types_tw.clear()
         for name, page in self.resource_type_pages.items():
             self.resource_types_tw.addTab(page, name.capitalize())
 
-        self.oacs_client.request_started.connect(self.handle_search_started)
-        self.oacs_client.request_ended.connect(self.handle_search_ended)
+        oacs_client.request_started.connect(self.handle_search_started)
+        oacs_client.request_ended.connect(self.handle_search_ended)
 
         self._connection_controls = (
             self.connection_list_cmb,
@@ -147,10 +141,10 @@ class OacsDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, DataSourceWidge
             utils.clear_search_results(widget_page.search_results_layout)
 
     def handle_search_started(self):
-        utils.toggle_widgets_enabled(self._interactive_widgets, force_state=True)
+        utils.toggle_widgets_enabled(self._interactive_widgets, force_state=False)
 
     def handle_search_ended(self):
-        utils.toggle_widgets_enabled(self._interactive_widgets, force_state=False)
+        utils.toggle_widgets_enabled(self._interactive_widgets, force_state=True)
 
     def _spawn_data_source_connection_deletion_dialog(self, connection_name: str):
         message = f"Remove connection {connection_name!r}?"

--- a/src/qgis_oacs/gui/search_datastream_items_widget.py
+++ b/src/qgis_oacs/gui/search_datastream_items_widget.py
@@ -4,13 +4,17 @@ from qgis.PyQt import QtWidgets
 from qgis.PyQt.uic import loadUiType
 
 from .. import (
-    client,
     models,
     utils,
 )
+from ..client import (
+    oacs_client,
+    OacsRequestMetadata,
+    RequestType,
+)
 from ..constants import IconPath
 from ..settings import settings_manager
-from .list_item_widgets import ListItemWidget
+from .list_item_widgets import DataStreamListItemWidget
 
 SearchDataStreamItemsWidgetUi, _ = loadUiType(
     Path(__file__).parents[1] / "ui/search_datastream_items_widget.ui")
@@ -23,37 +27,33 @@ class SearchDataStreamItemsWidget(QtWidgets.QWidget, SearchDataStreamItemsWidget
 
     _interactive_widgets: tuple[QtWidgets.QWidget, ...]
 
-    oacs_client: client.OacsClient
-
     def __init__(
             self,
-            oacs_client: client.OacsClient,
             parent: QtWidgets.QWidget=None
     ) -> None:
         super().__init__(parent)
         self.setupUi(self)
-        self.oacs_client = oacs_client
         self.search_pb.setIcon(utils.create_icon_from_svg(IconPath.search))
         self._interactive_widgets = (
             self.free_text_le,
             self.search_pb,
         )
         self.search_pb.clicked.connect(self.initiate_search)
-        self.oacs_client.request_started.connect(self.handle_request_started)
-        self.oacs_client.request_ended.connect(self.handle_request_ended)
-        self.oacs_client.system_list_fetched.connect(self.handle_search_response)
+        oacs_client.request_started.connect(self.handle_request_started)
+        oacs_client.request_ended.connect(self.handle_request_ended)
+        oacs_client.datastream_list_fetched.connect(self.handle_search_response)
 
-    def handle_request_started(self, metadata: client.OacsRequestMetadata) -> None:
+    def handle_request_started(self, metadata: OacsRequestMetadata) -> None:
         if metadata.request_type in (
-            client.RequestType.DATASTREAM_LIST,
-            client.RequestType.DATASTREAM_ITEM,
+            RequestType.DATASTREAM_LIST,
+            RequestType.DATASTREAM_ITEM,
         ):
             self.toggle_interactive_widgets(force_state=False)
 
-    def handle_request_ended(self, metadata: client.OacsRequestMetadata) -> None:
+    def handle_request_ended(self, metadata: OacsRequestMetadata) -> None:
         if metadata.request_type in (
-                client.RequestType.DATASTREAM_LIST,
-                client.RequestType.DATASTREAM_ITEM,
+                RequestType.DATASTREAM_LIST,
+                RequestType.DATASTREAM_ITEM,
         ):
             self.toggle_interactive_widgets(force_state=True)
 
@@ -63,12 +63,14 @@ class SearchDataStreamItemsWidget(QtWidgets.QWidget, SearchDataStreamItemsWidget
     def initiate_search(self) -> None:
         utils.clear_search_results(self.search_results_layout)
         connection = settings_manager.get_current_data_source_connection()
-        self.oacs_client.initiate_datastream_list_search(
-            connection,
-        )
+        oacs_client.initiate_datastream_list_search(connection)
 
-    def handle_search_response(self, datastream_list: models.DataStreamList) -> None:
+    def handle_search_response(
+            self,
+            datastream_list: models.DataStreamList,
+            request_metadata: OacsRequestMetadata
+    ) -> None:
         for datastream_item in datastream_list.items:
-            display_widget = ListItemWidget(resource=datastream_item)
+            display_widget = DataStreamListItemWidget(datastream_item)
             self.search_results_layout.addWidget(display_widget)
         self.search_results_layout.addStretch()

--- a/src/qgis_oacs/gui/search_sampling_feature_items_widget.py
+++ b/src/qgis_oacs/gui/search_sampling_feature_items_widget.py
@@ -4,13 +4,17 @@ from qgis.PyQt import QtWidgets
 from qgis.PyQt.uic import loadUiType
 
 from .. import (
-    client,
     models,
     utils,
 )
+from ..client import (
+    oacs_client,
+    OacsRequestMetadata,
+    RequestType,
+)
 from ..constants import IconPath
 from ..settings import settings_manager
-from .list_item_widgets import ListItemWidget
+from .list_item_widgets import SamplingFeatureListItemWidget
 
 SearchSamplingFeatureItemsWidgetUi, _ = loadUiType(
     Path(__file__).parents[1] / "ui/search_sampling_feature_items_widget.ui")
@@ -26,37 +30,33 @@ class SearchSamplingFeatureItemsWidget(
 
     _interactive_widgets: tuple[QtWidgets.QWidget, ...]
 
-    oacs_client: client.OacsClient
-
     def __init__(
             self,
-            oacs_client: client.OacsClient,
             parent: QtWidgets.QWidget=None
     ) -> None:
         super().__init__(parent)
         self.setupUi(self)
-        self.oacs_client = oacs_client
         self.search_pb.setIcon(utils.create_icon_from_svg(IconPath.search))
         self._interactive_widgets = (
             self.free_text_le,
             self.search_pb,
         )
         self.search_pb.clicked.connect(self.initiate_search)
-        self.oacs_client.request_started.connect(self.handle_request_started)
-        self.oacs_client.request_ended.connect(self.handle_request_ended)
-        self.oacs_client.system_list_fetched.connect(self.handle_search_response)
+        oacs_client.request_started.connect(self.handle_request_started)
+        oacs_client.request_ended.connect(self.handle_request_ended)
+        oacs_client.sampling_feature_list_fetched.connect(self.handle_search_response)
 
-    def handle_request_started(self, metadata: client.OacsRequestMetadata) -> None:
+    def handle_request_started(self, metadata: OacsRequestMetadata) -> None:
         if metadata.request_type in (
-            client.RequestType.SAMPLING_FEATURE_LIST,
-            client.RequestType.SAMPLING_FEATURE_ITEM,
+            RequestType.SAMPLING_FEATURE_LIST,
+            RequestType.SAMPLING_FEATURE_ITEM,
         ):
             self.toggle_interactive_widgets(force_state=False)
 
-    def handle_request_ended(self, metadata: client.OacsRequestMetadata) -> None:
+    def handle_request_ended(self, metadata: OacsRequestMetadata) -> None:
         if metadata.request_type in (
-                client.RequestType.SAMPLING_FEATURE_LIST,
-                client.RequestType.SAMPLING_FEATURE_ITEM,
+                RequestType.SAMPLING_FEATURE_LIST,
+                RequestType.SAMPLING_FEATURE_ITEM,
         ):
             self.toggle_interactive_widgets(force_state=True)
 
@@ -66,12 +66,16 @@ class SearchSamplingFeatureItemsWidget(
     def initiate_search(self) -> None:
         utils.clear_search_results(self.search_results_layout)
         connection = settings_manager.get_current_data_source_connection()
-        self.oacs_client.initiate_sampling_feature_list_search(
+        oacs_client.initiate_sampling_feature_list_search(
             connection,
         )
 
-    def handle_search_response(self, sampling_feature_list: models.SamplingFeatureList) -> None:
+    def handle_search_response(
+            self,
+            sampling_feature_list: models.SamplingFeatureList,
+            request_metadata: OacsRequestMetadata
+    ) -> None:
         for sampling_feature_item in sampling_feature_list.items:
-            display_widget = ListItemWidget(resource=sampling_feature_item)
+            display_widget = SamplingFeatureListItemWidget(sampling_feature_item)
             self.search_results_layout.addWidget(display_widget)
         self.search_results_layout.addStretch()

--- a/src/qgis_oacs/gui/search_system_items_widget.py
+++ b/src/qgis_oacs/gui/search_system_items_widget.py
@@ -4,13 +4,17 @@ from qgis.PyQt import QtWidgets
 from qgis.PyQt.uic import loadUiType
 
 from .. import (
-    client,
     models,
     utils,
 )
+from ..client import (
+    oacs_client,
+    OacsRequestMetadata,
+    RequestType,
+)
 from ..constants import IconPath
 from ..settings import settings_manager
-from .list_item_widgets import ListItemWidget
+from .list_item_widgets import SystemListItemWidget
 
 SearchSystemItemsWidgetUi, _ = loadUiType(
     Path(__file__).parents[1] / "ui/search_system_items_widget.ui")
@@ -25,18 +29,14 @@ class SearchSystemItemsWidget(QtWidgets.QWidget, SearchSystemItemsWidgetUi):
     search_pb: QtWidgets.QPushButton
     search_results_layout: QtWidgets.QVBoxLayout
 
-    oacs_client: client.OacsClient
-
     _interactive_widgets: tuple[QtWidgets.QWidget, ...]
 
     def __init__(
             self,
-            oacs_client: client.OacsClient,
             parent: QtWidgets.QWidget=None
     ) -> None:
         super().__init__(parent)
         self.setupUi(self)
-        self.oacs_client = oacs_client
         self.search_pb.setIcon(utils.create_icon_from_svg(IconPath.search))
         self._interactive_widgets = (
             self.free_text_le,
@@ -44,21 +44,21 @@ class SearchSystemItemsWidget(QtWidgets.QWidget, SearchSystemItemsWidgetUi):
             self.advanced_filters_gb,
         )
         self.search_pb.clicked.connect(self.initiate_search)
-        self.oacs_client.request_started.connect(self.handle_request_started)
-        self.oacs_client.request_ended.connect(self.handle_request_ended)
-        self.oacs_client.system_list_fetched.connect(self.handle_search_response)
+        oacs_client.request_started.connect(self.handle_request_started)
+        oacs_client.request_ended.connect(self.handle_request_ended)
+        oacs_client.system_list_fetched.connect(self.handle_search_response)
 
-    def handle_request_started(self, metadata: client.OacsRequestMetadata) -> None:
+    def handle_request_started(self, metadata: OacsRequestMetadata) -> None:
         if metadata.request_type in (
-                client.RequestType.SYSTEM_LIST,
-                client.RequestType.SYSTEM_ITEM,
+                RequestType.SYSTEM_LIST,
+                RequestType.SYSTEM_ITEM,
         ):
             self.toggle_interactive_widgets(force_state=False)
 
-    def handle_request_ended(self, metadata: client.OacsRequestMetadata) -> None:
+    def handle_request_ended(self, metadata: OacsRequestMetadata) -> None:
         if metadata.request_type in (
-            client.RequestType.SYSTEM_LIST,
-            client.RequestType.SYSTEM_ITEM,
+            RequestType.SYSTEM_LIST,
+            RequestType.SYSTEM_ITEM,
         ):
             self.toggle_interactive_widgets(force_state=True)
 
@@ -71,13 +71,17 @@ class SearchSystemItemsWidget(QtWidgets.QWidget, SearchSystemItemsWidgetUi):
     def initiate_search(self) -> None:
         utils.clear_search_results(self.search_results_layout)
         connection = settings_manager.get_current_data_source_connection()
-        self.oacs_client.initiate_system_list_search(
+        oacs_client.initiate_system_list_search(
             connection,
             q_filter=self.free_text_le.text()
         )
 
-    def handle_search_response(self, system_list: models.SystemList) -> None:
+    def handle_search_response(
+            self,
+            system_list: models.SystemList,
+            request_metadata: OacsRequestMetadata
+    ) -> None:
         for system_item in system_list.items:
-            display_widget = ListItemWidget(resource=system_item)
+            display_widget = SystemListItemWidget(system_item)
             self.search_results_layout.addWidget(display_widget)
         self.search_results_layout.addStretch()

--- a/src/qgis_oacs/main.py
+++ b/src/qgis_oacs/main.py
@@ -1,4 +1,3 @@
-import qgis.core
 from qgis.gui import (
     QgsGui,
     QgisInterface,

--- a/src/qgis_oacs/models.py
+++ b/src/qgis_oacs/models.py
@@ -220,13 +220,14 @@ class Conformance:
 
 @dataclasses.dataclass(frozen=True)
 class ClientSearchParams:
-    path: str
+    url_or_relative_path: str
     query: dict[str, str | float | int | bool | list[str | float | int | bool]] | None = None
     headers: dict[str, str] | None = None
     body: bytes | None = None
 
 
 class OacsFeatureProtocol(typing.Protocol):
+    id_: str
     name: str
     summary: str
     icon_tooltip: str


### PR DESCRIPTION
This PR refactors the code in order to separate the business logic of interacting with a remote OACS server from the plugin GUI. This makes it easier to reason about  the code

The newly-introduced `client.py` module contains the `OacsClient` class, which inherits from `QObject`. It implements a client for interacting with an OACS server while using QGIS' network classes and async tasks.