### PR TITLE
Replaced naming "OACS" to "CSAPI"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# QGIS OACS Plugin
+# QGIS CSAPI Plugin
 
 Check out the docs at:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# QGIS OACS Plugin
+# QGIS CSAPI Plugin
 
 ![Inspirational screenshot](images/qgis-oacs-motivational.png)
 
@@ -20,7 +20,7 @@ A [QGIS] plugin for working with [OGC API - Connected Systems] servers
 
 ---
 
-This is a QGIS plugin to work with OACS servers. It allows you to discover and visualize datasets exposed as OCS
+This is a QGIS plugin to work with CSAPI servers. It allows you to discover and visualize datasets exposed as OCS
 resources.
 
 ## Installation
@@ -40,7 +40,7 @@ the callout below.
     1. Add this custom repository inside QGIS Plugin Manager
     1. Allow experimental plugins
     1. Refresh the list of available plugins
-    1. Search for a plugin named **OACS**
+    1. Search for a plugin named **CSAPI**
     1. Install it!
 
 Proceed to the [User guide](user-guide.md) section for next steps.

--- a/docs/known-servers.md
+++ b/docs/known-servers.md
@@ -8,7 +8,7 @@ The following is a list of servers which are known to implement the OGC API - Co
 - https://csa.demo.52north.org/ - as of now, this server's TLS certificate is not valid, so one needs to skip TLS
   verification in order to use it.
 - https://api.georobotix.io/ogc/demo1/api/systems - the [opensensorhub docs] claim this is a good demo server
-  for OACS - seems to be down though (responds with HTTP 502)
+  for CSAPI - seems to be down though (responds with HTTP 502)
 - https://os4csapi-osh.duckdns.org/sensorhub/api - it contains tons of data for systems, deployments and other resources - it is protected by
   auth (credentials supplied offline)
 - 

--- a/docs/third-party.md
+++ b/docs/third-party.md
@@ -1,6 +1,6 @@
 # Third-party resources
 
-The QGIS OACS Plugin makes use of some third-party works. All credit goes to original authors, 
+The QGIS CSAPI Plugin makes use of some third-party works. All credit goes to original authors, 
 and thanks for making awesome stuff that can be used by other projects!
 
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,7 +1,7 @@
 # User guide
 
-The QGIS OACS plugin allows you to browse through the resources exposed by servers that implement the 
-[OGC API - Connected Systems] (OACS) standard.
+The QGIS CSAPI plugin allows you to browse through the resources exposed by servers that implement the 
+[OGC API - Connected Systems] (CSAPI) standard.
 
 
 [OGC API - Connected Systems]: https://ogcapi.ogc.org/connectedsystems/
@@ -22,32 +22,32 @@ you can install it from our private repo, as mentioned in the callout below.
     1. Add this custom repository inside QGIS Plugin Manager
     1. Allow experimental plugins
     1. Refresh the list of available plugins
-    1. Search for a plugin named **OACS**
+    1. Search for a plugin named **CSAPI**
     1. Install it!
 
 
 ## Overview
 
-QGIS OACS plugin has the following components:
+QGIS CSAPI plugin has the following components:
 
-- A QGIS data source selector - this allows configuring connections to OACS servers, 
+- A QGIS data source selector - this allows configuring connections to CSAPI servers, 
   discovering resources and loading them onto QGIS
-- A panel that shows currently loaded OACS resources and allows browsing their connected resources for further 
+- A panel that shows currently loaded CSAPI resources and allows browsing their connected resources for further 
   inspection and loading
 - A panel for visualizing observation results
 
 
-## OACS Data source selector
+## CSAPI Data source selector
 
 The Data source selector is where you configure connections and load resources onto the QGIS map canvas.
 Open it from the QGIS Data Source Manager, or via **Plugins → OGC API Connected Systems → Open data source selector**.
 
-![QGIS OACS plugin data source selector](images/data-source-selector.png)
+![QGIS CSAPI plugin data source selector](images/data-source-selector.png)
 
 
 ### Managing connections
 
-Use the connection bar at the top to create, edit, or remove connections to OACS servers. Each connection
+Use the connection bar at the top to create, edit, or remove connections to CSAPI servers. Each connection
 stores the server URL, an optional name, and authentication settings.
 
 
@@ -76,13 +76,13 @@ In each tab:
     Resources that have a spatial location have their icon colorized in green 
 
 
-## OACS resources panel
+## CSAPI resources panel
 
-The OACS Resources panel is a dockable panel that tracks every OACS resource you have loaded onto the
+The CSAPI Resources panel is a dockable panel that tracks every CSAPI resource you have loaded onto the
 map canvas. It lets you explore related resources without reopening the data source selector.
-It can be shown/hidden by pressing the QGIS OACS button shown in the QGIS toolbar.
+It can be shown/hidden by pressing the QGIS CSAPI button shown in the QGIS toolbar.
 
-![QGIS OACS plugin resource panel](images/oacs-panel.png)
+![QGIS CSAPI plugin resource panel](images/oacs-panel.png)
 
 The panel shows a tree, which is organized as:
 
@@ -105,9 +105,9 @@ To load a related resource onto the map, select it and use the **Add to map** bu
     Resources that have a spatial location have their icon colorized in green 
 
 
-## OACS observations panel
+## CSAPI observations panel
 
-The OACS Observations panel displays raw observation results for a datastream. It appears automatically
+The CSAPI Observations panel displays raw observation results for a datastream. It appears automatically
 when observation data is retrieved.
 
 The panel shows:
@@ -115,7 +115,7 @@ The panel shows:
 - The name of the datastream whose observations are being displayed.
 - The observation payloads as plain text, pretty-printed if the content is JSON.
 
-![QGIS OACS plugin observations panel](images/observations-panel.png)
+![QGIS CSAPI plugin observations panel](images/observations-panel.png)
 
 Two actions are available:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: QGIS OACS plugin
+site_name: QGIS CSAPI plugin
 site_url: https://byteroad.github.io/qgis-oacs-plugin
 repo_url: https://github.com/byteroad/qgis-oacs-plugin
 
@@ -9,7 +9,7 @@ nav:
   - Changelog: "changelog-base.md"
   - QGIS Repo: "repo/plugins.xml"
   - Third-party credits: "third-party.md"
-  - Known OACS servers: "known-servers.md"
+  - Known CSAPI servers: "known-servers.md"
 
 theme:
   name: material

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ plugin-admin = "plugindev.pluginadmin:app"
 package = true
 
 [tool.qgis-plugin.metadata]
-name = "QGIS OACS Plugin"
+name = "QGIS CSAPI Plugin"
 qgisMinimumVersion = "3.40.0"
 icon = "graph_3.svg"
 experimental = true

--- a/src/qgis_oacs/constants.py
+++ b/src/qgis_oacs/constants.py
@@ -6,7 +6,7 @@ SPATIAL_COLOR = QtGui.QColor("#2a9d8f")
 
 
 # ---------------------------------------------------------------------------
-# OACS layer custom property keys
+# CSAPI layer custom property keys
 # ---------------------------------------------------------------------------
 
 OACS_SCHEMA_VERSION_KEY = "oacs/schema_version"

--- a/src/qgis_oacs/gui/data_source_widget.py
+++ b/src/qgis_oacs/gui/data_source_widget.py
@@ -175,7 +175,7 @@ class OacsDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, DataSourceWidge
         message = f"Remove connection {connection_name!r}?"
         confirmation = QtWidgets.QMessageBox.warning(
             self,
-            "QGIS OACS Plugin",
+            "QGIS CSAPI Plugin",
             message,
             QtWidgets.QMessageBox.Yes,
             QtWidgets.QMessageBox.No,

--- a/src/qgis_oacs/gui/detail_panel.py
+++ b/src/qgis_oacs/gui/detail_panel.py
@@ -1,4 +1,4 @@
-"""Shared detail panel widget for displaying OACS resource metadata."""
+"""Shared detail panel widget for displaying CSAPI resource metadata."""
 
 import typing
 
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 class ResourceDetailPanel(QtWidgets.QWidget):
     """Shows metadata and actions for the currently selected tree node.
 
-    Used both by the data source selector tree widgets and the OACS resource
+    Used both by the data source selector tree widgets and the CSAPI resource
     panel. Pass a ``connection`` explicitly when the active connection may
     differ from ``settings_manager.get_current_data_source_connection()``
     (e.g. in the panel where each entry has its own connection).

--- a/src/qgis_oacs/gui/oacs_panel.py
+++ b/src/qgis_oacs/gui/oacs_panel.py
@@ -1,4 +1,4 @@
-"""Dockable panel for navigating loaded OACS resources and their associations."""
+"""Dockable panel for navigating loaded CSAPI resources and their associations."""
 
 import uuid
 
@@ -49,7 +49,7 @@ def _connection_label(conn_id: uuid.UUID, fallback_url: str) -> str:
 
 
 class OacsResourcePanel(QtWidgets.QDockWidget):
-    """Dockable panel showing OACS resources loaded on the canvas.
+    """Dockable panel showing CSAPI resources loaded on the canvas.
 
     Three tree levels:
       Connection → Loaded resource → Link-rel groups → Browsed related resources
@@ -60,7 +60,7 @@ class OacsResourcePanel(QtWidgets.QDockWidget):
             iface: qgis.gui.QgisInterface,
             parent: QtWidgets.QWidget | None = None,
     ) -> None:
-        super().__init__("OACS Resources", parent)
+        super().__init__("CSAPI Resources", parent)
         self._iface = iface
         self._pending_link_requests: dict[uuid.UUID, QtWidgets.QTreeWidgetItem] = {}
         self._pending_detail_requests: dict[uuid.UUID, QtWidgets.QTreeWidgetItem] = {}
@@ -124,7 +124,7 @@ class OacsResourcePanel(QtWidgets.QDockWidget):
         entries_by_conn = layer_registry.entries_by_connection()
         if not entries_by_conn:
             placeholder = QtWidgets.QTreeWidgetItem(
-                ["No OACS resources loaded", ""], _PLACEHOLDER_TYPE)
+                ["No CSAPI resources loaded", ""], _PLACEHOLDER_TYPE)
             placeholder.setFlags(placeholder.flags() & ~QtCore.Qt.ItemIsSelectable)
             self._tree.addTopLevelItem(placeholder)
             return

--- a/src/qgis_oacs/gui/observations_panel.py
+++ b/src/qgis_oacs/gui/observations_panel.py
@@ -10,7 +10,7 @@ from ..settings import settings_manager
 
 class ObservationsPanel(QtWidgets.QDockWidget):
     def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
-        super().__init__("OACS Observations", parent)
+        super().__init__("CSAPI Observations", parent)
         self._datastream: models.DataStream | None = None
         self._pending_system_load_id: uuid.UUID | None = None
         self._build_ui()

--- a/src/qgis_oacs/gui/resource_tree_widgets.py
+++ b/src/qgis_oacs/gui/resource_tree_widgets.py
@@ -1,4 +1,4 @@
-"""Generic tree-based browser widgets for OACS resources.
+"""Generic tree-based browser widgets for CSAPI resources.
 
 Each concrete class pairs with one resource type. The shared infrastructure
 lives in OacsResourceTreeWidgetBase; subclasses only implement the three
@@ -49,7 +49,7 @@ class OacsResourceTreeWidgetBase(
     QtWidgets.QWidget,
     metaclass=AbstractQWidgetMeta,
 ):
-    """Abstract master-detail tree browser for a single OACS resource type.
+    """Abstract master-detail tree browser for a single CSAPI resource type.
 
     Subclasses implement three hooks:
       _connect_type_signals  — wire up the resource-specific client signals

--- a/src/qgis_oacs/main.py
+++ b/src/qgis_oacs/main.py
@@ -43,10 +43,10 @@ class QgisOacs:
 
         self._toggle_action = QtWidgets.QAction(
             QtGui.QIcon(IconPath.main_logo),
-            "Toggle OACS plugin panel",
+            "Toggle CSAPI plugin panel",
             self.iface.mainWindow(),
         )
-        self._toggle_action.setToolTip("Toggle OACS plugin panel")
+        self._toggle_action.setToolTip("Toggle CSAPI plugin panel")
         self._toggle_action.setCheckable(True)
         self._toggle_action.setChecked(False)
         self._toggle_action.toggled.connect(self._resource_panel.setVisible)

--- a/src/qgis_oacs/models.py
+++ b/src/qgis_oacs/models.py
@@ -28,7 +28,7 @@ class SystemType(enum.Enum):
 
     @classmethod
     def from_api_response(cls, value: str) -> "SystemType":
-        # OGC API-CS specifies SOSA types (sosa:), but some servers send SSN
+        # CSAPI specifies SOSA types (sosa:), but some servers send SSN
         # types (ssn:) instead. SSN and SOSA are closely aligned — ssn:System
         # is the parent of all SOSA system types — so we accept both.
         try:
@@ -120,7 +120,7 @@ class ProcedureType(enum.Enum):
                 "http://www.w3.org/ns/sosa/ObservingProcedure": ProcedureType.OBSERVING_PROCEDURE,
 
                 # this below `procedure/observation` type is not strictly conformant
-                # with the OGC API-CS document. However, some servers return it.
+                # with the CSAPI document. However, some servers return it.
                 # Seems likely that it comes from an older version of the standard, so
                 # we map it to ObservingProcedure
                 "http://www.opengis.net/def/procedure/observation": ProcedureType.OBSERVING_PROCEDURE,

--- a/src/qgis_oacs/registry.py
+++ b/src/qgis_oacs/registry.py
@@ -67,12 +67,12 @@ def _parse_layer(layer: qgis.core.QgsMapLayer) -> OacsLayerEntry | None:
             links=[models.Link(**lnk) for lnk in raw_links],
         )
     except Exception as err:
-        log_message(f"Could not parse OACS layer properties from {layer.name()!r}: {err}")
+        log_message(f"Could not parse CSAPI layer properties from {layer.name()!r}: {err}")
         return None
 
 
 class OacsLayerRegistry(QtCore.QObject):
-    """Tracks QGIS layers that were loaded from an OACS resource."""
+    """Tracks QGIS layers that were loaded from a CSAPI resource."""
 
     registry_changed = QtCore.pyqtSignal()
 

--- a/src/qgis_oacs/tasks.py
+++ b/src/qgis_oacs/tasks.py
@@ -23,7 +23,7 @@ class CollectionListNetworkRequestTask(qgis.core.QgsTask):
             self,
             network_request_timeout: int,
             authcfg_id: str | None = None,
-            description: str = "oacs-plugin-network-request-task",
+            description: str = "csapi-plugin-network-request-task",
     ):
         super().__init__(description)
         self.authcfg_id = authcfg_id

--- a/src/qgis_oacs/utils.py
+++ b/src/qgis_oacs/utils.py
@@ -146,7 +146,7 @@ def set_oacs_layer_properties(
         connection: "DataSourceConnectionSettings",
         resource: "models.OacsItem",
 ) -> None:
-    """Write OACS context onto a QGIS layer's custom properties."""
+    """Write CSAPI context onto a QGIS layer's custom properties."""
     self_link = resource.get_detail_url(connection.base_url)
     layer.setCustomProperty(OACS_SCHEMA_VERSION_KEY, OACS_SCHEMA_VERSION)
     layer.setCustomProperty(OACS_CONNECTION_ID_KEY, str(connection.id))


### PR DESCRIPTION
- Only user-facing strings were updated
-  Filenames, variables, etc were kept
- The repo name is also kept