### PR TITLE
- fixed deprecated GH actions command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,8 @@ jobs:
       - name: get zip details
         id: get-zip-details
         run: |
-          echo "::set-output name=ZIP_PATH::dist/$(ls dist)\n"
-          echo "::set-output name=ZIP_NAME::$(ls dist)"
+          echo "ZIP_PATH=dist/$(ls dist)" >> "$GITHUB_OUTPUT"
+          echo "ZIP_NAME=$(ls dist)" >> "$GITHUB_OUTPUT"
 
       - name: Get experimental info
         id: get-experimental


### PR DESCRIPTION
https://github.blog/changelog/2022-10-10-github-actions-deprecating-save-state-and-set-output-commands/